### PR TITLE
Deprecated  update  method that preventing delete to friend

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -413,7 +413,7 @@ function plugin (options) {
         var update = {$pull: {}}
         update.$pull[pathName] = {_id: m2};
         return function (done) {
-          collection.update({_id: m1}, update, done);
+          collection.updateMany({_id: m1}, update, done);
         }
       }
 


### PR DESCRIPTION
(node:16080) DeprecationWarning: collection.update is deprecated. Use updateOne, updateMany, or bulkWrite instead.